### PR TITLE
Add a bash script version

### DIFF
--- a/bash/README.md
+++ b/bash/README.md
@@ -1,0 +1,17 @@
+## Bash
+
+### Usage
+Executing the bash script will:
+1. Execute `npm outdated` in the current dir
+1. Collect all the outdated deps
+1. Execute `npm i {dep1}@latest {dep2}@latest`, updating all deps to latest
+
+_Executing the bash script_
+```bash
+sh ./bumpall.sh
+```
+
+### Development
+1. `cd` into the `npm_dir` folder
+1. Run the bumpall script with `sh ../bumpall.sh`
+1. Run `sh ./downgrade_deps.sh` to revert deps to original state

--- a/bash/bumpall.sh
+++ b/bash/bumpall.sh
@@ -9,7 +9,7 @@ fi
 
 printf "Outdated dependencies\n\n${outdated}\n\n"
 
-regex="^[a-z@\-]+ "
+regex="^[a-z\/@\-]+ "
 command="npm i"
 
 while IFS= read -r line; do

--- a/bash/bumpall.sh
+++ b/bash/bumpall.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ -p /dev/stdin ]; then
+  regex="^[a-z@\-]+ "
+  output="npm i"
+
+  count=0
+  while read line
+  do
+    if [[ $line =~ $regex ]]
+    then
+      package=$BASH_REMATCH
+      # trim off the trailing space
+      package="${package// }"
+      output="${output} ${package}@latest"
+    fi
+  done
+
+  echo "${output}"
+else
+  echo "Pipe the results of npm outdated to this script"
+fi

--- a/bash/bumpall.sh
+++ b/bash/bumpall.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
 
-if [ -p /dev/stdin ]; then
-  regex="^[a-z@\-]+ "
-  output="npm i"
+outdated=$(npm outdated)
 
-  count=0
-  while read line
-  do
-    if [[ $line =~ $regex ]]
-    then
-      package=$BASH_REMATCH
-      # trim off the trailing space
-      package="${package// }"
-      output="${output} ${package}@latest"
-    fi
-  done
-
-  echo "${output}"
-else
-  echo "Pipe the results of npm outdated to this script"
+if [ "$outdated" = "" ]; then
+  printf "All dependencies are up to date!\n"
+  exit 0
 fi
+
+printf "Outdated dependencies\n\n${outdated}\n\n"
+
+regex="^[a-z@\-]+ "
+command="npm i"
+
+while IFS= read -r line; do
+  if [[ $line =~ $regex ]]
+  then
+    package=$BASH_REMATCH
+    # trim off the trailing space
+    package="${package// }"
+    command="${command} ${package}@latest"
+  fi
+done <<< "$outdated"
+
+printf "Running:\n$command\n\n"
+$command

--- a/bash/npm_dir/.gitignore
+++ b/bash/npm_dir/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bash/npm_dir/downgrade_deps.sh
+++ b/bash/npm_dir/downgrade_deps.sh
@@ -1,3 +1,1 @@
-cd ./npm_dir
-
 exec npm i left-pad@1.2.0 polished@3.6.5

--- a/bash/npm_dir/downgrade_deps.sh
+++ b/bash/npm_dir/downgrade_deps.sh
@@ -1,0 +1,3 @@
+cd ./npm_dir
+
+exec npm i left-pad@1.2.0 polished@3.6.5

--- a/bash/npm_dir/downgrade_deps.sh
+++ b/bash/npm_dir/downgrade_deps.sh
@@ -1,1 +1,1 @@
-exec npm i left-pad@1.2.0 polished@3.6.5
+exec npm i left-pad@1.2.0 polished@3.6.5 @types/jest@26.0.2

--- a/bash/npm_dir/package-lock.json
+++ b/bash/npm_dir/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "npm_dir",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/runtime": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "left-pad": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+    },
+    "polished": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.5.tgz",
+      "integrity": "sha512-VwhC9MlhW7O5dg/z7k32dabcAFW1VI2+7fSe8cE/kXcfL7mVdoa5UxciYGW2sJU78ldDLT6+ROEKIZKFNTnUXQ==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+    }
+  }
+}

--- a/bash/npm_dir/package-lock.json
+++ b/bash/npm_dir/package-lock.json
@@ -12,6 +12,128 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@jest/types": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+      "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^3.0.0"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "26.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.2.tgz",
+      "integrity": "sha512-rJB5DZm6q6kILGvQVxMRXOteoMjvA10UlGDf7+hM6pcMiWQiTgxaPXKC+kYCTAdBe9y33O+n3WZ8dzvBKOTSmA==",
+      "requires": {
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      }
+    },
+    "@types/yargs": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+      "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+    },
+    "ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "requires": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      }
+    },
+    "chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "diff-sequences": {
+      "version": "25.2.6",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+      "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg=="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "jest-diff": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+      "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+      "requires": {
+        "chalk": "^3.0.0",
+        "diff-sequences": "^25.2.6",
+        "jest-get-type": "^25.2.6",
+        "pretty-format": "^25.5.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "25.2.6",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+      "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig=="
+    },
     "left-pad": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
@@ -25,10 +147,34 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "pretty-format": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+      "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+      "requires": {
+        "@jest/types": "^25.5.0",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^16.12.0"
+      }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
     }
   }
 }

--- a/bash/npm_dir/package.json
+++ b/bash/npm_dir/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/jest": "^26.0.2",
     "left-pad": "^1.2.0",
     "polished": "^3.6.5"
   }

--- a/bash/npm_dir/package.json
+++ b/bash/npm_dir/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "npm_dir",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "left-pad": "^1.2.0",
+    "polished": "^3.6.5"
+  }
+}


### PR DESCRIPTION
1. Execute `npm outdated` in the current dir
1. Collect all the outdated deps
1. Execute `npm i {dep1}@latest {dep2}@latest`, updating all deps to latest

Used Regex capture groups for the text - seemed the cleanest way to handle it