### PR TITLE
NPM fix for windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn main() {
 
     print_message("Upgrading packages", &DIZZY);
 
-    let mut install = process::Command::new("npm")
+    let mut install = process::Command::new(NPM)
         .stdout(config.stdout_method)
         .stderr(config.stderr_method)
         .arg("i")

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,10 @@ use package::{Package, UpgradeType};
 use utility::{print_message, Config, UpgradeStyle};
 
 #[cfg(windows)]
-pub const NPM: &'static str = "npm.cmd";
+pub const NPM: & str = "npm.cmd";
 
 #[cfg(not(windows))]
-pub const NPM: &'static str = "npm";
+pub const NPM: & str = "npm";
 
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,19 @@ use emojis::{CACTUS, CROSS, DIZZY, MAGNIFYING_GLASS, POINT_RIGHT, ROCKET, TROPHY
 use package::{Package, UpgradeType};
 use utility::{print_message, Config, UpgradeStyle};
 
+#[cfg(windows)]
+pub const NPM: &'static str = "npm.cmd";
+
+#[cfg(not(windows))]
+pub const NPM: &'static str = "npm";
+
+
 fn main() {
     let config = Config::new_from_args(env::args());
 
     print_message("Checking for outdated packages...", &MAGNIFYING_GLASS);
 
-    let output = process::Command::new("npm")
+    let output = process::Command::new(NPM)
         .arg("outdated")
         .arg("--parseable")
         .output()

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,10 @@ use package::{Package, UpgradeType};
 use utility::{print_message, Config, UpgradeStyle};
 
 #[cfg(windows)]
-pub const NPM: & str = "npm.cmd";
+pub const NPM: &str = "npm.cmd";
 
 #[cfg(not(windows))]
-pub const NPM: & str = "npm";
-
+pub const NPM: &str = "npm";
 
 fn main() {
     let config = Config::new_from_args(env::args());


### PR DESCRIPTION
Running `npm` on windows will not work providing a `program not found` error.

This configuration allows it to work on windows and non-windows.

See: https://stackoverflow.com/questions/57310019/installing-npm-package-with-rust-stdprocesscommand
