### PR TITLE
Handle missing package

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -335,8 +335,7 @@ mod package_tests {
         let args = vec![String::from("--latest")];
         let config = Config::new_from_args(args.into_iter());
         // location:name@wanted_version:MISSING:name@latest_version
-        let provided =
-            String::from("location:@jonshort/cenv@1.0.3:MISSING:@jonshort/cenv@1.0.3");
+        let provided = String::from("location:@jonshort/cenv@1.0.3:MISSING:@jonshort/cenv@1.0.3");
         let pkg = Package::new(provided, &config)?;
 
         let expected = Package {

--- a/src/package.rs
+++ b/src/package.rs
@@ -21,8 +21,14 @@ fn val_or_err<T>(opt: Option<T>) -> Result<T, ParseError> {
     }
 }
 
+const MISSING: &str = "MISSING";
+
 fn split_name_and_version(src: Option<&str>) -> Result<(String, String), ParseError> {
     let src = val_or_err(src)?;
+
+    if src == MISSING {
+        return Ok((String::from(""), String::from(MISSING)));
+    }
 
     let is_scoped_package = src.starts_with('@');
     let mut segments = src.split('@');
@@ -63,6 +69,7 @@ pub struct Package {
 
 impl Package {
     pub fn new(src: String, config: &Config) -> Result<Package, ParseError> {
+        // :name@wanted_version:MISSING:name@latest_version:project
         // location:name@wanted_version:name@current_version:name@latest_version:project
         let mut segments = src.split(':');
         let _location = val_or_err(segments.next())?;
@@ -312,6 +319,28 @@ mod package_tests {
 
         let expected = Package {
             current_version: String::from("1.0.2"),
+            install_cmd: String::from("@jonshort/cenv@1.0.3"),
+            latest_version: String::from("1.0.3"),
+            name: String::from("@jonshort/cenv"),
+            skip: false,
+            upgrade_type: UpgradeType::Safe,
+            wanted_version: String::from("1.0.3"),
+        };
+        assert_eq!(pkg, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn expected_result_on_valid_input_7() -> Result<(), ParseError> {
+        let args = vec![String::from("--latest")];
+        let config = Config::new_from_args(args.into_iter());
+        // location:name@wanted_version:MISSING:name@latest_version
+        let provided =
+            String::from("location:@jonshort/cenv@1.0.3:MISSING:@jonshort/cenv@1.0.3");
+        let pkg = Package::new(provided, &config)?;
+
+        let expected = Package {
+            current_version: String::from("MISSING"),
             install_cmd: String::from("@jonshort/cenv@1.0.3"),
             latest_version: String::from("1.0.3"),
             name: String::from("@jonshort/cenv"),


### PR DESCRIPTION
Fix running the code when you haven't installed any packages yet.
`npm outdated --parseable` returns:
```
:@jonshort/cenv@0.0.6:MISSING:@jonshort/cenv@0.1.0:npm_dir
:left-pad@1.3.0:MISSING:left-pad@1.3.0:npm_dir
:polished@3.7.2:MISSING:polished@4.2.2:npm_dir
```

Normal installation looks like:
```
D:\Git\npm-bumpall\npm_dir\node_modules\@jonshort\cenv:@jonshort/cenv@0.0.6:@jonshort/cenv@0.0.6:@jonshort/cenv@0.1.0:npm_dir
D:\Git\npm-bumpall\npm_dir\node_modules\left-pad:left-pad@1.3.0:left-pad@1.2.0:left-pad@1.3.0:npm_dir
D:\Git\npm-bumpall\npm_dir\node_modules\polished:polished@3.7.2:polished@3.6.5:polished@4.2.2:npm_dir
```