### PR TITLE
Fix windows package parse

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -2,6 +2,12 @@ use std::{error::Error, fmt};
 
 use crate::utility::{Config, UpgradeStyle};
 
+#[cfg(windows)]
+pub const IS_WINDOWS: bool = true;
+
+#[cfg(not(windows))]
+pub const IS_WINDOWS: bool = false;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParseError;
 
@@ -72,6 +78,11 @@ impl Package {
         // :name@wanted_version:MISSING:name@latest_version:project
         // location:name@wanted_version:name@current_version:name@latest_version:project
         let mut segments = src.split(':');
+
+        if IS_WINDOWS {
+            segments.next();
+        }
+
         let _location = val_or_err(segments.next())?;
         let (name, wanted_version) = split_name_and_version(segments.next())?;
         let (_, current_version) = split_name_and_version(segments.next())?;


### PR DESCRIPTION
When parsing out the package string, the results on window contains the drive directory. For example:

```
"D:\\Documents\\Git\\npm-bumpall\\npm_dir\\node_modules\\polished:polished@3.7.2:polished@3.6.5:polished@4.2.2:npm_dir"
"/mnt/d/Users/JT/Documents/Git/npm-bumpall/npm_dir/node_modules/polished:polished@3.7.2:polished@3.6.5:polished@4.2.2:npm_dir"
```

Since we split on `:`, we need to handle the parsing differently on windows against macOS/Linux

Also noticed there `npm_dir` at the end.