### PR TITLE
Switch to npm outdated --json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ name = "npm-bumpall"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "serde",
  "serde_json",
  "serial_test",
 ]
@@ -401,9 +402,23 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
 
 [[package]]
 name = "serde_json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,9 @@ fn main() {
         process::exit(70)
     });
 
-    let split_by_eol: Vec<&str> = output.split_terminator('\n').collect();
-    let packages: Vec<Package> = split_by_eol
+    let packages: Vec<Package> = output
         .iter()
-        .filter_map(|&s| match Package::new(s.into(), &config) {
+        .filter_map(|(s, v)| match Package::new(s.into(), v, &config) {
             Ok(pkg) => {
                 if pkg.skip {
                     None
@@ -40,6 +39,8 @@ fn main() {
             Err(_) => None,
         })
         .collect();
+
+    eprint!("{:?}", packages);
 
     if packages.is_empty() {
         println!("{} No outdated packages found {}", &ROCKET, &ROCKET);


### PR DESCRIPTION
Switch `npm outdated` to output a json instead of a parseable string.

TODO:
- Check if `dependent` is set up correctly to match workspace
- Any additional tests required for json parsing
- How to deal wiht previous `MISSING` scenario

Resolves: https://github.com/JonShort/npm-bumpall/issues/21