### PR TITLE
Add --include arg which allows glob-based matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +277,7 @@ name = "npm-bumpall"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "glob",
  "serde_json",
  "serial_test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_json = "1"
 clap = { version = "4", features = ["derive"] }
+glob = "0.3"
+serde_json = "1"
 
 
 [dev-dependencies]

--- a/src/emojis.rs
+++ b/src/emojis.rs
@@ -4,4 +4,5 @@ pub const DIZZY: char = '\u{1F4AB}';
 pub const MAGNIFYING_GLASS: char = '\u{1F50D}';
 pub const POINT_RIGHT: char = '\u{1F449}';
 pub const ROCKET: char = '\u{1F680}';
+pub const THINKING: char = '\u{1F914}';
 pub const TROPHY: char = '\u{1F3C6}';

--- a/src/emojis.rs
+++ b/src/emojis.rs
@@ -4,5 +4,4 @@ pub const DIZZY: char = '\u{1F4AB}';
 pub const MAGNIFYING_GLASS: char = '\u{1F50D}';
 pub const POINT_RIGHT: char = '\u{1F449}';
 pub const ROCKET: char = '\u{1F680}';
-pub const THINKING: char = '\u{1F914}';
 pub const TROPHY: char = '\u{1F3C6}';

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod npm_cmd;
 mod package;
 mod utility;
 
-use emojis::{CACTUS, CROSS, DIZZY, MAGNIFYING_GLASS, POINT_RIGHT, ROCKET, THINKING, TROPHY};
+use emojis::{CACTUS, CROSS, DIZZY, MAGNIFYING_GLASS, POINT_RIGHT, ROCKET, TROPHY};
 use package::{Package, UpgradeType};
 use utility::{print_message, Config, UpgradeStyle};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod npm_cmd;
 mod package;
 mod utility;
 
-use emojis::{CACTUS, CROSS, DIZZY, MAGNIFYING_GLASS, POINT_RIGHT, ROCKET, TROPHY};
+use emojis::{CACTUS, CROSS, DIZZY, MAGNIFYING_GLASS, POINT_RIGHT, ROCKET, THINKING, TROPHY};
 use package::{Package, UpgradeType};
 use utility::{print_message, Config, UpgradeStyle};
 
@@ -78,6 +78,18 @@ fn main() {
         })
         .map(|pkg| String::from(&pkg.install_cmd))
         .collect();
+
+    if cmd_args.is_empty() {
+        eprintln!(
+            "{} No packages match provided glob - you provided \"{}\"",
+            THINKING,
+            config.include_glob.unwrap().as_str()
+        );
+        println!(
+            "For more info on glob patterns, see https://en.wikipedia.org/wiki/Glob_(programming)"
+        );
+        process::exit(74)
+    }
 
     print_message(&format!("Upgrading {} packages", cmd_args.len()), &DIZZY);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,10 @@ fn main() {
 
     let cmd_args: Vec<String> = packages
         .iter()
+        .filter(|x| match &config.include_glob {
+            Some(glob) => glob.matches(&x.name),
+            None => true,
+        })
         .map(|pkg| String::from(&pkg.install_cmd))
         .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
         .map(|pkg| String::from(&pkg.install_cmd))
         .collect();
 
-    print_message("Upgrading packages", &DIZZY);
+    print_message(&format!("Upgrading {} packages", cmd_args.len()), &DIZZY);
 
     let mut install = process::Command::new(NPM)
         .stdout(config.stdout_method)

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,16 @@ fn main() {
         process::exit(74)
     }
 
+    if config.include_glob.is_some() {
+        print_message(
+            &format!(
+                "Include glob provided - \"{}\"",
+                config.include_glob.unwrap().as_str()
+            ),
+            &MAGNIFYING_GLASS,
+        );
+    }
+
     print_message(&format!("Upgrading {} packages", cmd_args.len()), &DIZZY);
 
     let mut install = process::Command::new(NPM)


### PR DESCRIPTION
Addresses #19

## Changes
* Added the "official" glob crate - https://crates.io/crates/glob
* Config now includes an `include_glob` entry, which is an `Option<Pattern>`
* The packages with available updates are now also checked vs. provided glob (if provided)

## Example
<img width="714" alt="image" src="https://github.com/JonShort/npm-bumpall/assets/21317379/022ed83a-841a-4827-9d50-1065fe1c525f">