### PR TITLE
Dry run as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,17 @@ Utility to bump npm packages, by default to the latest minor version.
 Main feature is also updating the `package.json`, rather than just updating the version in the lockfile (e.g. like how `npm update` works)
 
 ## Usage
-_Execute the binary_
+_Execute the binary to see available updates_
 ```bash
 ~/repos/npm-bumpall/rust/target/release/npm-bumpall
 ```
+
+_To accept these updates, pass the `-u` or `--update` flag_
+```bash
+~/repos/npm-bumpall/rust/target/release/npm-bumpall -u
+```
+
+![image](https://github.com/JonShort/npm-bumpall/assets/21317379/cd884d87-2a8d-4099-83b7-99e1be30744a)
 
 ### Options
 

--- a/npm_dir/package-lock.json
+++ b/npm_dir/package-lock.json
@@ -9,8 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "workspaces": [
-        "a",
-        "b",
         "workspaces/a",
         "workspaces/b"
       ],

--- a/src/emojis.rs
+++ b/src/emojis.rs
@@ -1,4 +1,3 @@
-pub const CACTUS: char = '\u{1F335}';
 pub const CROSS: char = '\u{274C}';
 pub const DIZZY: char = '\u{1F4AB}';
 pub const MAGNIFYING_GLASS: char = '\u{1F50D}';

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod npm_cmd;
 mod package;
 mod utility;
 
-use emojis::{CACTUS, CROSS, DIZZY, MAGNIFYING_GLASS, POINT_RIGHT, ROCKET, TROPHY};
+use emojis::{CROSS, DIZZY, MAGNIFYING_GLASS, POINT_RIGHT, ROCKET, TROPHY};
 use package::{Package, UpgradeType};
 use utility::{print_message, Config, UpgradeStyle};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,13 @@ fn main() {
     println!();
 
     if config.is_dry_run {
-        print_message("Dry run, exiting...", &CACTUS);
+        print_message(
+            &format!(
+                "{} updates available, pass --update or -u to update",
+                packages.len(),
+            ),
+            &ROCKET,
+        );
         process::exit(0);
     }
 

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -25,8 +25,8 @@ pub struct Args {
     pub verbose: bool,
 
     #[arg(short, long)]
-    ///List dependencies which would be bumped, but don't update them
-    pub dry_run: bool,
+    ///Update outdated dependencies
+    pub update: bool,
 
     #[arg(short, long)]
     ///Only bumps packages which match the glob pattern provided
@@ -112,7 +112,7 @@ impl Config {
             additional_install_args,
             current_dir_name,
             include_glob,
-            is_dry_run: args.dry_run,
+            is_dry_run: !args.update,
             is_patch_mode: args.patch,
             stderr_method,
             stdout_method,
@@ -151,7 +151,7 @@ mod config_tests {
             additional_install_args: vec![],
             current_dir_name: Some(String::from("npm-bumpall")),
             include_glob: None,
-            is_dry_run: false,
+            is_dry_run: true,
             is_patch_mode: false,
             stderr_method: Stdio::null(),
             stdout_method: Stdio::null(),
@@ -172,7 +172,7 @@ mod config_tests {
             additional_install_args: vec![],
             current_dir_name: Some(String::from("npm-bumpall")),
             include_glob: None,
-            is_dry_run: false,
+            is_dry_run: true,
             is_patch_mode: false,
             stderr_method: Stdio::null(),
             stdout_method: Stdio::null(),
@@ -193,7 +193,7 @@ mod config_tests {
             additional_install_args: vec![String::from("--legacy-peer-deps")],
             current_dir_name: Some(String::from("npm-bumpall")),
             include_glob: None,
-            is_dry_run: false,
+            is_dry_run: true,
             is_patch_mode: false,
             stderr_method: Stdio::null(),
             stdout_method: Stdio::null(),
@@ -215,7 +215,7 @@ mod config_tests {
             additional_install_args: vec![],
             current_dir_name: Some(String::from("npm-bumpall")),
             include_glob: None,
-            is_dry_run: false,
+            is_dry_run: true,
             is_patch_mode: false,
             stderr_method: Stdio::inherit(),
             stdout_method: Stdio::inherit(),
@@ -226,9 +226,9 @@ mod config_tests {
 
     #[test]
     #[parallel]
-    fn handles_dry_run_arg() {
+    fn handles_update_arg() {
         let args_a = Args {
-            dry_run: true,
+            update: true,
             ..Args::default()
         };
         let result_a = Config::new_from_args(args_a);
@@ -236,7 +236,7 @@ mod config_tests {
             additional_install_args: vec![],
             current_dir_name: Some(String::from("npm-bumpall")),
             include_glob: None,
-            is_dry_run: true,
+            is_dry_run: false,
             is_patch_mode: false,
             stderr_method: Stdio::null(),
             stdout_method: Stdio::null(),
@@ -256,7 +256,7 @@ mod config_tests {
             additional_install_args: vec![],
             current_dir_name: Some(String::from("test_files")),
             include_glob: None,
-            is_dry_run: false,
+            is_dry_run: true,
             is_patch_mode: false,
             stderr_method: Stdio::null(),
             stdout_method: Stdio::null(),
@@ -279,7 +279,7 @@ mod config_tests {
             additional_install_args: vec![],
             current_dir_name: Some(String::from("npm-bumpall")),
             include_glob: None,
-            is_dry_run: false,
+            is_dry_run: true,
             is_patch_mode: true,
             stderr_method: Stdio::null(),
             stdout_method: Stdio::null(),
@@ -300,7 +300,7 @@ mod config_tests {
             additional_install_args: vec![],
             current_dir_name: Some(String::from("npm-bumpall")),
             include_glob: Some(Pattern::new("hello").unwrap()),
-            is_dry_run: false,
+            is_dry_run: true,
             is_patch_mode: false,
             stderr_method: Stdio::null(),
             stdout_method: Stdio::null(),
@@ -313,7 +313,7 @@ mod config_tests {
     #[parallel]
     fn handles_combo_args() {
         let args_a = Args {
-            dry_run: true,
+            update: true,
             include: Some(String::from(".*")),
             latest: true,
             legacy_peer_deps: true,
@@ -325,7 +325,7 @@ mod config_tests {
             additional_install_args: vec![String::from("--legacy-peer-deps")],
             current_dir_name: Some(String::from("npm-bumpall")),
             include_glob: Some(Pattern::new(".*").unwrap()),
-            is_dry_run: true,
+            is_dry_run: false,
             is_patch_mode: true,
             stderr_method: Stdio::inherit(),
             stdout_method: Stdio::inherit(),


### PR DESCRIPTION
Currently, running `bumpall` with no arguments results in packages being bumped to the latest safe version. However as developers we often want to know _what_ a tool will do before running it.

To help facilitate this, and reduce accidental updates, I've chosen to make "dry run" the default, and make users pass in `--update` or `-u` to actually update the dependencies

<img width="659" alt="image" src="https://github.com/JonShort/npm-bumpall/assets/21317379/359fdfaf-ca1c-46fe-b76f-6ea1a3733e10">

# Acknowledgements
This was suggested by @jaysc months ago